### PR TITLE
added ENV option for defining service addresses

### DIFF
--- a/src/main/java/org/streampipes/examples/sources/config/ExampleSourcesConfig.java
+++ b/src/main/java/org/streampipes/examples/sources/config/ExampleSourcesConfig.java
@@ -54,19 +54,43 @@ public enum ExampleSourcesConfig implements PeConfig {
     config = SpConfig.getSpConfig(SERVICE_ID);
 
     /*
+    FOR CONFIGURING SERVICES VIA ENVIRONMENT VARIABLES
+    */
+    String peHost = System.getenv("PE_HOST");
+    String kafkaHost = System.getenv("KAFKA_HOST");
+    String zkHost = System.getenv("ZOOKEEPER_HOST");
+    String iconHost = System.getenv("ICON_HOST");
+
+    if (peHost != null && !peHost.isEmpty())
+      config.register(HOST, peHost, "Hostname for the examples-sources project");
+    else
+      config.register(HOST, "pe-examples-sources", "Hostname for the examples-sources project");
+
+    if (kafkaHost != null && !kafkaHost.isEmpty())
+      config.register(KAFKA_HOST, kafkaHost, "Host for kafka of the pe demonstrator project");
+    else
+      config.register(KAFKA_HOST, "kafka", "Host for kafka of the pe demonstrator project");
+
+    if (zkHost != null && !zkHost.isEmpty())
+      config.register(ZOOKEEPER_HOST, zkHost, "Host for zookeeper of the pe demonstrator project");
+    else
+      config.register(ZOOKEEPER_HOST, "zookeeper", "Host for zookeeper of the pe demonstrator project");
+
+    if (iconHost != null && !iconHost.isEmpty())
+      config.register(ICON_HOST, iconHost, "Hostname for the icon host");
+    else
+      config.register(ICON_HOST, "backend", "Hostname for the icon host");
+
+    /*
       TUTORIAL:
       The second parameter is the default value for the configuration property.
       This value is set in Consul when the parameter does not exist.
       Important. Changes here are not effective if the configuration parameter is already set in consul. In
       such cases the value has to be changed in consul directly.
     */
-    config.register(HOST, "pe-examples-sources", "Hostname for the examples-sources project");
     config.register(PORT, 8090, "Port of the sources project");
-    config.register(KAFKA_HOST, "kafka", "Host for kafka of the pe demonstrator project");
     config.register(KAFKA_PORT, 9092, "Port for kafka of the pe demonstrator project");
-    config.register(ZOOKEEPER_HOST, "zookeeper", "Host for zookeeper of the pe demonstrator project");
     config.register(ZOOKEEPER_PORT, 2181, "Port for zookeeper of the pe demonstrator project");
-    config.register(ICON_HOST, "backend", "Hostname for the icon host");
     config.register(ICON_PORT, 80, "Port for the icons in nginx");
     config.register(SERVICE_NAME, "Example Sources", "StreamPipes example sources");
   }

--- a/src/main/java/org/streampipes/examples/sources/simulator/ExampleSourceDataSimulator.java
+++ b/src/main/java/org/streampipes/examples/sources/simulator/ExampleSourceDataSimulator.java
@@ -23,6 +23,7 @@ import net.acesinc.data.json.generator.config.JSONConfigReader;
 import net.acesinc.data.json.generator.config.SimulationConfig;
 import net.acesinc.data.json.generator.config.WorkflowConfig;
 import net.acesinc.data.json.generator.workflow.Workflow;
+import org.streampipes.examples.sources.config.ExampleSourcesConfig;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -46,8 +47,11 @@ public class ExampleSourceDataSimulator implements Runnable {
   }
 
   private SimulationConfig buildSimulationConfig() throws IOException {
-    return JSONConfigReader.readConfig(SimulationUtils.class.getClassLoader().getResourceAsStream(EXAMPLES_CONFIG_FILE),
-            SimulationConfig.class);
+    SimulationConfig simulationConfig = JSONConfigReader.readConfig(SimulationUtils.class.getClassLoader().getResourceAsStream(EXAMPLES_CONFIG_FILE),SimulationConfig.class);
+    // Get Kafka host from config
+    simulationConfig.getProducers().get(1).replace("broker.server", ExampleSourcesConfig.INSTANCE.getKafkaHost());
+
+    return simulationConfig;
   }
 
   private Map<String, Workflow> buildSimWorkflows(SimulationConfig config) throws IOException {


### PR DESCRIPTION
**Problem:** 
IP addresses of backend services (Flink, Consul, etc.) are hard coded and specifically aim for local deployment only, where service names are DNS resolvable. However, in a cluster setup, e.g. within Rancher when not deploying all services within the same stack the services names are not resolvable other than `<servicename>.<stackname>`. Therefore, one would need to change the service name in consul after deployment. In addition, the data simulator uses hard coded value for `broker.server`:

```json
"broker.server": "kafka"
```

**Solution:**
In order to deploy the PE's in a cluster environment, it might be useful to pre-specify the service addresses such that the PE itself is registrating the correct IP's within Consul in advance. So you could easily configure the addresses while starting the corresponding docker container (excerpt from the `docker-compose.yml` for Rancher). Additionally, the data simulator uses the `getKafkaHost()` method to retrieve the corresponding value, e.g. `KAFKA_HOST` if specified or default `kafka`.

```yaml
  pe-examples-sources:
    image: registry.biggis.project.de/streampipes/pe-examples-sources:0.51.1-rancher
    ports:
      - "8098:8090"
    environment:
      - PE_HOST=pe-examples-sources.nodes
      - CONSUL_LOCATION=consul.storage
      - KAFKA_HOST=kafka.middleware
      - ZOOKEEPER_HOST=zookeeper.middleware
      - ICON_HOST=backend.modelling
    labels:
      io.rancher.container.pull_image: always
    logging:
      driver: "json-file"
      options:
        max-size: "1m"
        max-file: "1"
```